### PR TITLE
chore: update environment variables to be set via runtime APP_ENV

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,5 @@
-NEXT_APP_EXP_BACKEND=https://explorer-api.aiblock.ch/api
-NEXT_APP_NETWORK=Devnet
-NEXT_APP_WEBSITE=https://explorer.aiblock.ch/
+NEXT_APP_EXP_BACKEND=http://loki.explorer.se3ker.com/api
+NEXT_APP_NETWORK=Developement
+NEXT_APP_OUTLINK=https://explorer.aiblock.ch/
 NEXT_APP_PORT=8080
-NEXT_APP_STORAGE_URL=https://storage.aiblock.ch
+NEXT_APP_STORAGE_URL=https://storage.aiblock.dev

--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,5 @@
 NEXT_APP_EXP_BACKEND=https://explorer-api.aiblock.ch/api
-NEXT_APP_NETWORK=Mainnet
+NEXT_APP_NETWORK=Devnet
 NEXT_APP_WEBSITE=https://explorer.aiblock.ch/
 NEXT_APP_PORT=8080
 NEXT_APP_STORAGE_URL=https://storage.aiblock.ch

--- a/.env.production
+++ b/.env.production
@@ -1,5 +1,5 @@
 NEXT_APP_EXP_BACKEND=https://explorer-api.aiblock.ch/api
 NEXT_APP_NETWORK=Mainnet
-NEXT_APP_WEBSITE=https://explorer.aiblock.ch/
+NEXT_APP_OUTLINK=https://explorer.aiblock.dev/
 NEXT_APP_PORT=8080
 NEXT_APP_STORAGE_URL=https://storage.aiblock.ch

--- a/.env.staging
+++ b/.env.staging
@@ -1,0 +1,5 @@
+NEXT_APP_EXP_BACKEND=https://explorer-api.aiblock.ch/api
+NEXT_APP_NETWORK=Testnet
+NEXT_APP_WEBSITE=https://explorer.aiblock.dev/
+NEXT_APP_PORT=8080
+NEXT_APP_STORAGE_URL=https://storage.aiblock.dev

--- a/.env.staging
+++ b/.env.staging
@@ -1,5 +1,5 @@
-NEXT_APP_EXP_BACKEND=https://explorer-api.aiblock.ch/api
+NEXT_APP_EXP_BACKEND=http://loki.explorer.se3ker.com/api
 NEXT_APP_NETWORK=Testnet
-NEXT_APP_WEBSITE=https://explorer.aiblock.dev/
+NEXT_APP_OUTLINK=https://explorer.aiblock.ch/
 NEXT_APP_PORT=8080
 NEXT_APP_STORAGE_URL=https://storage.aiblock.dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,11 +14,10 @@ RUN \
 # Copy and build for release
 COPY . .
 ENV NEXT_TELEMETRY_DISABLED 1
-ARG BUILD_ENV
 RUN \
-  if [ -f yarn.lock ]; then yarn run build:${BUILD_ENV}; \
-  elif [ -f package-lock.json ]; then npm run build:${BUILD_ENV}; \
-  elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm run build:${BUILD_ENV}; \
+  if [ -f yarn.lock ]; then yarn run build; \
+  elif [ -f package-lock.json ]; then npm run build; \
+  elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm run build; \
   else echo "Lockfile not found." && exit 1; \
   fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,11 @@ RUN \
 # Copy and build for release
 COPY . .
 ENV NEXT_TELEMETRY_DISABLED 1
+ARG BUILD_ENV
 RUN \
-  if [ -f yarn.lock ]; then yarn run build; \
-  elif [ -f package-lock.json ]; then npm run build; \
-  elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm run build; \
+  if [ -f yarn.lock ]; then yarn run build:${BUILD_ENV}; \
+  elif [ -f package-lock.json ]; then npm run build:${BUILD_ENV}; \
+  elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm run build:${BUILD_ENV}; \
   else echo "Lockfile not found." && exit 1; \
   fi
 
@@ -30,8 +31,13 @@ ENV HOSTNAME "0.0.0.0"
 
 USER node
 
-COPY --from=build /app/.next/standalone ./
-COPY --from=build /app/.next/static ./.next/static
+COPY --from=build /app/.next ./.next
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/package.json ./package.json
+COPY --from=build /app/.env.development ./.env.development
+COPY --from=build /app/.env.staging ./.env.staging
+COPY --from=build /app/.env.production ./.env.production
+COPY --from=build --chown=node:node /app/public ./public
 
-ENTRYPOINT ["node"]
-CMD ["server.js"]
+ENTRYPOINT ["/bin/sh", "-c"]
+CMD ["npm run prep && npm start"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The AIBlock explorer, for auditing and viewing the blockchain.
 
 ```
 npm install
-npm start dev
+npm run dev
 ```
 
 This will install all required dependencies for the project and start it up in development mode at  [http://localhost:3000](http://localhost:3000). 

--- a/app/constants.ts
+++ b/app/constants.ts
@@ -1,8 +1,10 @@
+import env from "@beam-australia/react-env";
+
 /** NETWORK */
-export const STORAGE_URL = process.env.STORAGE_URL
-export const EXP_BACKEND = process.env.EXP_BACKEND
-export const NETWORK = process.env.NEXT_PUBLIC_NETWORK
-export const WEBSITE = process.env.NEXT_PUBLIC_WEBSITE
+export const STORAGE_URL = env("STORAGE_URL")
+export const EXP_BACKEND = env("EXP_BACKEND")
+export const NETWORK = env("NETWORK")
+export const WEBSITE = env("WEBSITE")
 
 /** BLOCKS */
 export const BLOCK_TABLE_HEADERS = ["Number", "Block Hash", "Previous Hash", "Nb of Tx", "Age"]

--- a/app/constants.ts
+++ b/app/constants.ts
@@ -22,7 +22,7 @@ export const COINBASE_FIELDS = ['Coinbase Hash', 'Token Reward', 'Fractionated T
 
 /** TOKEN */
 export const TOKEN_FRACTION = 72072000 // Will change on network update
-export const TOKEN_CURRENCY = 'ABC'
+export const TOKEN_CURRENCY = 'ABC$'
 
 /** ADDRESS */
 export const ADDRESS_FIELDS = ['Address', 'Balance', 'Fractionated Token']

--- a/app/interfaces/general.interfaces.ts
+++ b/app/interfaces/general.interfaces.ts
@@ -135,8 +135,8 @@ export interface FetchedBlock extends Block {
 export interface Coinbase {
     druid_info: null
     fees: any[]
-    inputs: any[]
-    outputs: any[]
+    ins: any[]
+    outs: any[]
     version: number
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import Navbar from '@/app/ui/nav/navbar'
 import Footer from './ui/nav/footer'
 import '@/app/styles/globals.css'
 import { inter } from '@/app/styles/fonts'
+import Script from 'next/script'
 
 export default function RootLayout({
   children,
@@ -11,12 +12,13 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className={`${inter.className} antialiased overflow-y-auto overflow-x-hidden`}>
+       <body className={`${inter.className} antialiased overflow-y-auto overflow-x-hidden`}>
         <Navbar />
         <main className="flex h-auto min-h-[calc(100vh-64px)] overflow-y-hidden flex-col p-6 border overflow-x-auto">
           {children}
         </main>
         <Footer />
+        <Script src="__ENV.js" strategy="beforeInteractive" />
       </body>
     </html>
   )

--- a/app/ui/nav/navbar.tsx
+++ b/app/ui/nav/navbar.tsx
@@ -16,7 +16,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/app/ui/tooltip"
-import { NETWORK, WEBSITE } from '@/app/constants'
+import env from '@beam-australia/react-env'
 
 interface NavItems {
   name: string,
@@ -45,9 +45,13 @@ export default function Navbar() {
   let router = useRouter()
   const pathname = usePathname()
   const [current, setCurrent] = useState(pathname)
-
+  const [NETWORK, setNetwork] = useState('')
+  const [WEBSITE, setWebsite] = useState('')
+  
   useEffect(() => {
     setCurrent(pathname)
+    setNetwork(env("NETWORK"))
+    setWebsite(env("WEBSITE"))
   }, [pathname])
 
   return (

--- a/app/ui/nav/navbar.tsx
+++ b/app/ui/nav/navbar.tsx
@@ -46,12 +46,12 @@ export default function Navbar() {
   const pathname = usePathname()
   const [current, setCurrent] = useState(pathname)
   const [NETWORK, setNetwork] = useState('')
-  const [WEBSITE, setWebsite] = useState('')
+  const [LINK, setLink] = useState('')
   
   useEffect(() => {
     setCurrent(pathname)
     setNetwork(env("NETWORK"))
-    setWebsite(env("WEBSITE"))
+    setLink(env("OUTLINK"))
   }, [pathname])
 
   return (
@@ -128,12 +128,12 @@ export default function Navbar() {
                 <TooltipProvider delayDuration={100}>
                   <Tooltip>
                     <TooltipTrigger>
-                      <div className='px-2 flex flex-row bg-green-200 rounded-sm'>
-                        <a href={WEBSITE}>
+                      <div className={`px-2 flex flex-row ${NETWORK == 'Mainnet' ? 'bg-green-200 ' : 'bg-orange-200'} rounded-sm`}>
+                        <a href={LINK}>
                           <TooltipContent>
-                            {`Click here to change to ${WEBSITE == 'Mainnet' ? 'Mainnet' : 'Testnet'}`}
+                            {`Click here to change to `} <b>{NETWORK == 'Mainnet' ? 'Testnet' : 'Mainnet'}</b>
                           </TooltipContent>
-                          <Typography variant='small' className={`w-fit text-green-900 text-center ${fira.className} px-1`}>
+                          <Typography variant='small' className={`w-fit ${NETWORK == 'Mainnet' ? 'text-green-900' : 'text-orange-900'} text-center ${fira.className} px-1`}>
                            {NETWORK ? NETWORK.toUpperCase() : ''}
                           </Typography>
                         </a>

--- a/app/ui/nav/searchbar.tsx
+++ b/app/ui/nav/searchbar.tsx
@@ -37,8 +37,9 @@ export default function Searchbar() {
         if (isHash(input)) {
             if (input[0] == 'b') // block hash
                 router.push(`/block/${input}`)
-            if (input[0] == 'g') // tx hash
+            else if (input[0] == 'g') // tx hash
                 router.push(`/transaction/${input}`)
+            else
             router.push(`/address/${input}`)
         } else if (isNum(input))
             router.push(`/block/${input}`)

--- a/app/utils/data.utils.tsx
+++ b/app/utils/data.utils.tsx
@@ -117,11 +117,11 @@ export const formatTxTableRow = (tx: Transaction | any): TxRow => {
 
 export const formatToCoinbaseDisplay = (tx: Coinbase): CoinbaseDisplay => {
   const coinbase = {
-    tokens: tokenValue(tx.outputs[0].value.Token) + ' ' + TOKEN_CURRENCY,
-    fractionatedTokens: tx.outputs[0].value.Token.toString(),
-    locktime: tx.outputs[0].locktime.toString(),
+    tokens: tokenValue(tx.outs[0].amount) + ' ' + TOKEN_CURRENCY,
+    fractionatedTokens: tx.outs[0].amount.toString(),
+    locktime: tx.outs[0].locktime.toString(),
     version: tx.version.toString(),
-    scriptPubKey: tx.outputs[0].script_public_key,
+    scriptPubKey: tx.outs[0].scriptPublicKey,
   } as CoinbaseDisplay
   return coinbase
 }

--- a/app/utils/fetch.utils.tsx
+++ b/app/utils/fetch.utils.tsx
@@ -35,10 +35,10 @@ export const useBlockTxs = (id: string): TxRow[] => {
 }
 
 export const useCoinbaseTx = (id: string): CoinbaseDisplay | undefined => {
-    const { data } = useSWR(`/api/item/${id}`, config)
+    const { data } = useSWR(`/api/transaction/${id}`, config)
     if (data != undefined) {
-        if (data.content[0][1]) {
-            const coinbaseDisplay: CoinbaseDisplay = formatToCoinbaseDisplay(data.content[0][1] as Coinbase)
+        if (data.content) {
+            const coinbaseDisplay: CoinbaseDisplay = formatToCoinbaseDisplay(data.content as Coinbase)
             return coinbaseDisplay
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "block-explorer",
       "version": "0.2.0",
       "dependencies": {
+        "@beam-australia/react-env": "^3.1.1",
         "@headlessui/react": "^1.7.17",
         "@heroicons/react": "^2.0.18",
         "@material-tailwind/react": "^2.1.5",
@@ -17,6 +18,7 @@
         "next": "^14.0.4",
         "react": "^18",
         "react-dom": "^18",
+        "react-env": "^0.0.0",
         "sass": "^1.69.5",
         "swr": "^2.2.5",
         "tailwind-merge": "^2.2.1",
@@ -63,6 +65,81 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@beam-australia/react-env": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@beam-australia/react-env/-/react-env-3.1.1.tgz",
+      "integrity": "sha512-LdWzgqmu116t9+sOvONyB21bBmI8dm8g8s3KhnJVzCcK93GrdSisuIOtOkQPMYgenmVGTWQwWnbLAgoka/jAFw==",
+      "dependencies": {
+        "cross-spawn": "^6.0.5",
+        "dotenv": "^8.0.0",
+        "dotenv-expand": "^5.1.0",
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "react-env": "dist/cli.js"
+      }
+    },
+    "node_modules/@beam-australia/react-env/node_modules/cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dependencies": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      },
+      "engines": {
+        "node": ">=4.8"
+      }
+    },
+    "node_modules/@beam-australia/react-env/node_modules/path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@beam-australia/react-env/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/@beam-australia/react-env/node_modules/shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+      "dependencies": {
+        "shebang-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@beam-australia/react-env/node_modules/shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@beam-australia/react-env/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
       }
     },
     "node_modules/@emotion/is-prop-valid": {
@@ -1844,6 +1921,19 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dotenv": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
+      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
+      "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA=="
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.4.605",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.605.tgz",
@@ -3263,8 +3353,7 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "node_modules/iterator.prototype": {
       "version": "1.1.2",
@@ -3486,7 +3575,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -3602,6 +3690,11 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
     "node_modules/node-releases": {
       "version": "2.0.14",
@@ -4108,6 +4201,11 @@
       "peerDependencies": {
         "react": "^18.2.0"
       }
+    },
+    "node_modules/react-env": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/react-env/-/react-env-0.0.0.tgz",
+      "integrity": "sha512-kaZymS9Rgh58AVNNCTf1EewJKnGYtNJagmt3+omw0EvCNXhUOcdEXRT4qTCL3EECBx1dCA+2moBRN9QLj9PxJw=="
     },
     "node_modules/react-is": {
       "version": "16.13.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "AIBlock",
   "scripts": {
     "dev": "APP_ENV=development react-env --prefix NEXT_APP --env APP_ENV -- next",
-    "build:production": "next build",
+    "build": "next build",
     "start": "react-env --prefix NEXT_APP --env APP_ENV -- next start",
     "lint": "next lint",
     "prep": "react-env --prefix NEXT_APP --env APP_ENV"

--- a/package.json
+++ b/package.json
@@ -4,12 +4,14 @@
   "private": true,
   "author": "AIBlock",
   "scripts": {
-    "dev": "next dev",
-    "build": "next build",
-    "start": "next start",
-    "lint": "next lint"
+    "dev": "APP_ENV=development react-env --prefix NEXT_APP --env APP_ENV -- next",
+    "build:production": "next build",
+    "start": "react-env --prefix NEXT_APP --env APP_ENV -- next start",
+    "lint": "next lint",
+    "prep": "react-env --prefix NEXT_APP --env APP_ENV"
   },
   "dependencies": {
+    "@beam-australia/react-env": "^3.1.1",
     "@headlessui/react": "^1.7.17",
     "@heroicons/react": "^2.0.18",
     "@material-tailwind/react": "^2.1.5",
@@ -19,6 +21,7 @@
     "next": "^14.0.4",
     "react": "^18",
     "react-dom": "^18",
+    "react-env": "^0.0.0",
     "sass": "^1.69.5",
     "swr": "^2.2.5",
     "tailwind-merge": "^2.2.1",

--- a/public/__ENV.js
+++ b/public/__ENV.js
@@ -1,1 +1,1 @@
-window.__ENV = {"NEXT_APP_EXP_BACKEND":"https://explorer-api.aiblock.ch/api","NEXT_APP_NETWORK":"Devnet","NEXT_APP_WEBSITE":"https://explorer.aiblock.ch/","NEXT_APP_PORT":"8080","NEXT_APP_STORAGE_URL":"https://storage.aiblock.ch","REACT_ENV_PREFIX":"NEXT_APP"};
+window.__ENV = {"NEXT_APP_EXP_BACKEND":"http://loki.explorer.se3ker.com/api","NEXT_APP_NETWORK":"Developement","NEXT_APP_OUTLINK":"https://explorer.aiblock.ch/","NEXT_APP_PORT":"8080","NEXT_APP_STORAGE_URL":"https://storage.aiblock.dev","REACT_ENV_PREFIX":"NEXT_APP"};

--- a/public/__ENV.js
+++ b/public/__ENV.js
@@ -1,0 +1,1 @@
+window.__ENV = {"NEXT_APP_EXP_BACKEND":"https://explorer-api.aiblock.ch/api","NEXT_APP_NETWORK":"Devnet","NEXT_APP_WEBSITE":"https://explorer.aiblock.ch/","NEXT_APP_PORT":"8080","NEXT_APP_STORAGE_URL":"https://storage.aiblock.ch","REACT_ENV_PREFIX":"NEXT_APP"};


### PR DESCRIPTION
This PR addresses the following issue:

Currently different environment variables are required for testnet vs mainnet. These are both 'production' builds but they run in different environments.

Currently these variables are only accessible during **build-time**, which as an effect requires us to build images that target a specific environment. This violates a fundamental principle of devops: "Build once, run anywhere".

So ideally we would want one image that can run in both environments and switch out these variables during **runtime**.

See https://github.com/AIBlockOfficial/block-explorer/pull/18/files#r1562049460 for some information on the nuance of this new approach. 