### PR TITLE
fix: update coinbase tx fetch method

### DIFF
--- a/app/constants.ts
+++ b/app/constants.ts
@@ -20,7 +20,7 @@ export const COINBASE_FIELDS = ['Coinbase Hash', 'Token Reward', 'Fractionated T
 
 /** TOKEN */
 export const TOKEN_FRACTION = 72072000 // Will change on network update
-export const TOKEN_CURRENCY = 'ABC'
+export const TOKEN_CURRENCY = 'ABC$'
 
 /** ADDRESS */
 export const ADDRESS_FIELDS = ['Address', 'Balance', 'Fractionated Token']

--- a/app/interfaces/general.interfaces.ts
+++ b/app/interfaces/general.interfaces.ts
@@ -135,8 +135,8 @@ export interface FetchedBlock extends Block {
 export interface Coinbase {
     druid_info: null
     fees: any[]
-    inputs: any[]
-    outputs: any[]
+    ins: any[]
+    outs: any[]
     version: number
 }
 

--- a/app/utils/data.utils.tsx
+++ b/app/utils/data.utils.tsx
@@ -117,11 +117,11 @@ export const formatTxTableRow = (tx: Transaction | any): TxRow => {
 
 export const formatToCoinbaseDisplay = (tx: Coinbase): CoinbaseDisplay => {
   const coinbase = {
-    tokens: tokenValue(tx.outputs[0].value.Token) + ' ' + TOKEN_CURRENCY,
-    fractionatedTokens: tx.outputs[0].value.Token.toString(),
-    locktime: tx.outputs[0].locktime.toString(),
+    tokens: tokenValue(tx.outs[0].amount) + ' ' + TOKEN_CURRENCY,
+    fractionatedTokens: tx.outs[0].amount.toString(),
+    locktime: tx.outs[0].locktime.toString(),
     version: tx.version.toString(),
-    scriptPubKey: tx.outputs[0].script_public_key,
+    scriptPubKey: tx.outs[0].scriptPublicKey,
   } as CoinbaseDisplay
   return coinbase
 }

--- a/app/utils/fetch.utils.tsx
+++ b/app/utils/fetch.utils.tsx
@@ -35,10 +35,10 @@ export const useBlockTxs = (id: string): TxRow[] => {
 }
 
 export const useCoinbaseTx = (id: string): CoinbaseDisplay | undefined => {
-    const { data } = useSWR(`/api/item/${id}`, config)
+    const { data } = useSWR(`/api/transaction/${id}`, config)
     if (data != undefined) {
-        if (data.content[0][1]) {
-            const coinbaseDisplay: CoinbaseDisplay = formatToCoinbaseDisplay(data.content[0][1] as Coinbase)
+        if (data.content) {
+            const coinbaseDisplay: CoinbaseDisplay = formatToCoinbaseDisplay(data.content as Coinbase)
             return coinbaseDisplay
         }
     }


### PR DESCRIPTION
This PR addresses the following issue:

- Previously it was not possible to fetch coinbase transactions from explorer-backend service. As a temp fix, the coinbase transaction was fetched directly on chain with blockchain_items API endpoint. Changes has been made to backend, breaking the current frontend setup. 
- Currency indicator was missing '$' sign